### PR TITLE
Allow building without conan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ install:
     - conan profile new default --detect
     - conan profile update settings.compiler.libcxx=libstdc++11 default
     - mkdir build && cd build
-    - conan install ..
-    - cmake .. -DBUILD_TESTING=ON
+    - conan install .. -s build_type=Release
+    - cmake .. -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
     - make -j
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.12)
 
 project(CubicInterpolation LANGUAGES CXX)
 
+# To find conan files created in build directory
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
+
 set(CubicInterpolation_VERSION_MAJOR 0)
 set(CubicInterpolation_VERSION_MINOR 1)
 set(CubicInterpolation_VERSION_PATCH 3)
@@ -9,8 +13,8 @@ set(CubicInterpolation_VERSION ${CubicInterpolation_VERSION_MAJOR}.${CubicInterp
 
 set(CMAKE_CXX_STANDARD 14)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+find_package(Eigen3 CONFIG REQUIRED)
+find_package(Boost COMPONENTS filesystem math serialization REQUIRED)
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,11 @@ cmake_minimum_required(VERSION 3.12)
 project(CubicInterpolation LANGUAGES CXX)
 
 # To find conan files created in build directory
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
-list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_BINARY_DIR}")
+list(APPEND CMAKE_PREFIX_PATH "${PROJECT_BINARY_DIR}")
+
+message(STATUS ${CMAKE_PREFIX_PATH})
+message(STATUS ${CMAKE_MODULE_PATH})
 
 set(CubicInterpolation_VERSION_MAJOR 0)
 set(CubicInterpolation_VERSION_MINOR 1)

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,21 +19,21 @@ class CubicInterpolationConan(ConanFile):
         "fPIC": [True, False],
     }
     default_options = {
-        "shared": False,
+        "shared": True,
         "fPIC": True
     }
 
     exports_sources = "*"
-    generators = "cmake"
+    generators = "cmake_find_package", "cmake_find_package_multi"
     _cmake = None
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
+    # def config_options(self):
+    #     if self.settings.os == "Windows":
+    #         del self.options.fPIC
 
-    def configure(self):
-        if self.options.shared:
-            del self.options.fPIC
+    # def configure(self):
+    #     if self.options.shared:
+    #         del self.options.fPIC
 
     def requirements(self):
         self.requires("boost/1.75.0")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,10 +10,12 @@ endif()
 add_subdirectory(CubicInterpolation)
 add_subdirectory(detail)
 
-target_link_libraries(CubicInterpolation
-    CONAN_PKG::eigen
-    CONAN_PKG::boost
-    )
+target_link_libraries(CubicInterpolation PUBLIC
+    Eigen3::Eigen
+    Boost::boost
+)
+get_target_property(INCS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+message(STATUS "EIGEN INCLUDE ${INCS}")
 
 target_include_directories(CubicInterpolation PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -43,9 +45,6 @@ configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
     NO_CHECK_REQUIRED_COMPONENTS_MACRO
     )
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CubicInterpolationConfig.cmake
+install( FILES ${CMAKE_CURRENT_BINARY_DIR}/CubicInterpolationConfig.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CubicInterpolation
-    )
-
-install(FILES "${PROJECT_BINARY_DIR}/conanbuildinfo.cmake"
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CubicInterpolation)
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,8 @@ add_subdirectory(detail)
 target_link_libraries(CubicInterpolation PUBLIC
     Eigen3::Eigen
     Boost::boost
+    Boost::filesystem
+    Boost::serialization
 )
 get_target_property(INCS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
 message(STATUS "EIGEN INCLUDE ${INCS}")

--- a/src/Config.cmake.in
+++ b/src/Config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-include(${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+find_package(Eigen3 REQUIRED)
+find_package(Boost REQUIRED)
 
 include ("${CMAKE_CURRENT_LIST_DIR}/CubicInterpolationTargets.cmake")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,13 +13,13 @@ set(Libs
 # gtest_discover_tests(TestAxis)
 
 add_executable(TestCubicSplines TestCubicSplines.cpp)
-target_link_libraries(TestCubicSplines ${Libs})
+target_link_libraries(TestCubicSplines PRIVATE ${Libs})
 gtest_discover_tests(TestCubicSplines)
 
 add_executable(TestBicubicSplines TestBicubicSplines.cpp)
-target_link_libraries(TestBicubicSplines ${Libs})
+target_link_libraries(TestBicubicSplines PRIVATE ${Libs})
 gtest_discover_tests(TestBicubicSplines)
 
 add_executable(TestFindParameter TestFindParameter.cpp)
-target_link_libraries(TestFindParameter ${Libs})
+target_link_libraries(TestFindParameter PRIVATE ${Libs})
 gtest_discover_tests(TestFindParameter)


### PR DESCRIPTION
By removing the need for conan *inside* the cmake project, it can be build using system libraries / custom installations.

