### PR TITLE
Delete empty cxx file

### DIFF
--- a/src/detail/CMakeLists.txt
+++ b/src/detail/CMakeLists.txt
@@ -4,5 +4,4 @@ target_sources(CubicInterpolation PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/CubicSplines.cxx
     ${CMAKE_CURRENT_LIST_DIR}/FindParameter.cxx
     ${CMAKE_CURRENT_LIST_DIR}/InterpolantBuilder.cxx
-    ${CMAKE_CURRENT_LIST_DIR}/Interpolant.cxx
     )


### PR DESCRIPTION
Removes linker warnings such as `libCubicInterpolation.a(Interpolant.cxx.o) has no symbols` on apple clang