### PR TITLE
Decrease boost dependency to 1.72.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,55 @@
+# Installation
+
+We explain two different ways to install *cubic_interpolation*: With or without the package manager [*conan*](https://conan.io/).
+
+### Approach 1: Installation with conan
+
+For this installation approach, all dependencies will be fetched by the package manager conan.
+This way, you don't have to install them by yourself.
+
+If conan is not yet installed, you can do so, for example by using pip:
+
+```
+$ pip install conan
+```
+
+Clone the repository and create a build directory
+
+```
+$ git clone https://github.com/MaxSac/cubic_interpolation
+$ cd cubic_interpolation && mkdir build && cd build      
+```
+Use conan to fetch all dependencies:
+
+```
+$ conan install ..
+```
+
+Next, build and install *cubic_interpolation*:
+
+```
+$ conan build ..
+# cmake --install .
+```
+
+### Approach 2: Installation without conan
+
+If you do not want to use conan, you need to provide these dependencies:
+
+* [boost](https://www.boost.org/) (>1.75.0)
+* [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) (>3.3.9)
+
+If you have these dependencies installed, clone the repository and create a build directory:
+
+```
+$ git clone https://github.com/MaxSac/cubic_interpolation
+$ cd cubic_interpolation && mkdir build && cd build      
+```
+
+Use *CMake* and *make* to build and install *cubic_interpolation*:
+
+```
+$ cmake .. -DCMAKE_BUILD_TYPE=Release	# or other CMake options
+$ make -j
+# make install
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ $ conan build ..
 
 If you do not want to use conan, you need to provide these dependencies:
 
-* [boost](https://www.boost.org/) (>1.75.0)
+* [boost](https://www.boost.org/) (>1.72.0)
 * [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) (>3.3.9)
 
 If you have these dependencies installed, clone the repository and create a build directory:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cubic_interpolation [![Build Status](https://api.travis-ci.com/MaxSac/cubic_interpolation.svg?branch=main)](https://travis-ci.com/github/MaxSac/cubic_interpolation)
 
 A leightweight interpolation library based on boost and eigen.
-It's provide the utilities to handle tables which are runtime intensive to build
+It provides the utilities to handle tables which are runtime intensive to build
 and reduces interpolation failures to axis transformation.
 
 If runtime intensive interpolation tables are created over several orders of magnitude,
@@ -31,7 +31,9 @@ auto inter = Interpolant<CubicSplines<double>>(std::move(def), TABLS_PATH, TABLE
 auto res = inter.evaluate(point);
 ```
 
-More information can be found in the documentation which could be build with the
+More information can be found in the documentation which can be build with the
 flag `BUILD_DOCUMENTATION` with a sphinx and a doxygen target. 
+
+For information about the installation process look at the [INSTALL.md](https://github.com/MaxSac/cubic_interpolation/blob/main/INSTALL.md)
 
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class CubicInterpolationConan(ConanFile):
     #         del self.options.fPIC
 
     def requirements(self):
-        self.requires("boost/1.74.0")
+        self.requires("boost/1.72.0")
         self.requires("eigen/3.3.9")
 
     @property

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class CubicInterpolationConan(ConanFile):
     #         del self.options.fPIC
 
     def requirements(self):
-        self.requires("boost/1.75.0")
+        self.requires("boost/1.74.0")
         self.requires("eigen/3.3.9")
 
     @property


### PR DESCRIPTION
Boost version 1.75.0 is only supported on Linux kernels newer than 4.11 due to [some changes in the release](https://www.boost.org/users/history/version_1_75_0.html).

However, cubic_interpolation is also running fine with boost version 1.74.0.

To support older Linux kernels, it would be nice to decrease the requirement of the boost version (at least until we absolutely need something from a newer boost package).

This would solve [this issue](https://github.com/tudo-astroparticlephysics/PROPOSAL/issues/186) in PROPOSAL, at least for now.

We would also have to apply this change in conan-center-index.